### PR TITLE
RAITO 1501 Enable cron scheduling for CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,14 +25,15 @@ WORKDIR /
 RUN mkdir -p /config
 
 ENV TZ=Etc/UTC
-ENV CLI_FREQUENCY=60
+ENV CLI_FREQUENCY=1440
+ENV CLI_CRON=""
 ENV RAITO_CLI_UPDATE_CRON="0 2 * * *"
 ENV RAITO_CLI_CONTAINER_STDOUT_FILE="/dev/stdout"
 ENV RAITO_CLI_CONTAINER_STDERR_FILE="/dev/stderr"
 
 COPY --from=build /raito-cli-runner /raito-cli-runner
 
-ENTRYPOINT /raito-cli-runner run -f $CLI_FREQUENCY --config-file /config/raito.yml --log-output
+ENTRYPOINT /raito-cli-runner run -f $CLI_FREQUENCY -c $CLI_CRON --config-file /config/raito.yml --log-output
 
 
 ## Deploy-amazon
@@ -47,12 +48,13 @@ WORKDIR /
 RUN mkdir -p /config
 
 ENV TZ=Etc/UTC
-ENV CLI_FREQUENCY=60
+ENV CLI_FREQUENCY=1440
 ENV RAITO_CLI_UPDATE_CRON="0 2 * * *"
+ENV CLI_CRON=""
 ENV RAITO_CLI_CONTAINER_STDOUT_FILE="/dev/stdout"
 ENV RAITO_CLI_CONTAINER_STDERR_FILE="/dev/stderr"
 
 COPY --from=build /raito-cli-runner /raito-cli-runner
 
 ENTRYPOINT []
-CMD /raito-cli-runner run -f $CLI_FREQUENCY --config-file /config/raito.yml --log-output
+CMD /raito-cli-runner run -f $CLI_FREQUENCY -c $CLI_CRON --config-file /config/raito.yml --log-output

--- a/README.md
+++ b/README.md
@@ -34,14 +34,15 @@ The following environment variables are used in the default entrypoint:
 | Environment variable              | Description                                                                                       | Default Value |
 |-----------------------------------|---------------------------------------------------------------------------------------------------|---------------|
 | `TZ`                              | Timezone used by the container                                                                    | Etc/UTC       |
-| `CLI_FREQUENCY`                   | The frequency used to do the sync (in minutes).                                                   | 60            |
+| `CLI_FREQUENCY`                   | The frequency used to do the sync (in minutes).                                                   | 1440          |
+| `CLI_CRON`                        | Cron expression that defines when  to execute a sync (overwrite `CLI_FREQ`)                       |               |
 | `RAITO_CLI_UPDATE_CRON`           | The cronjob definition for when the container needs to check if a newer CLI version is available. | `0 2 * * *`   |
 | `RAITO_CLI_CONTAINER_STDOUT_FILE` | Output file stdout of the Raito CLI                                                               | `/dev/stdout` |
 | `RAITO_CLI_CONTAINER_STDERR_FILE` | Output file stderr of the Raito CLI                                                               | `/dev/stderr` |
 
 The default entrypoint of the container is defined as
 ```dockerfile
-ENTRYPOINT /raito-cli-runner run -f $CLI_FREQUENCY --config-file /config/raito.yml --log-output
+ENTRYPOINT /raito-cli-runner run -f $CLI_FREQUENCY -c $CLI_CRON --config-file /config/raito.yml --log-output
 ```
 
 You can override the default entrypoint by using the `--entrypoint` option when execution `docker run`


### PR DESCRIPTION
**THIS CAN ONLY BE MERGED IF https://github.com/raito-io/cli/pull/219 IS DEPLOYED**

Add `CLI_CRON` envvar to define CLI cron schedules